### PR TITLE
Fix: Corrigir erro 403 GitHub Actions Pages - Permissões GITHUB_TOKENFix: Adicionar permissões GITHUB_TOKEN para corrigir erro 403 PagesFi…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,13 @@ on:
   # Permite executar este workflow manualmente da aba Actions
   workflow_dispatch:
 
-# Configurar permissões para o GITHUB_TOKEN
+# Configurar permissões para o GITHUB_TOKEN - Fix para erro 403 no GitHub Actions Pages
 permissions:
   contents: write
   pages: write
   id-token: write
+  actions: read
+  deployments: write
 
 # Permitir apenas um deployment simultâneo
 concurrency:


### PR DESCRIPTION
## Descrição

Este PR corrige o erro 403 que ocorre no deployment do GitHub Actions Pages, adicionando as permissões necessárias ao GITHUB_TOKEN.

## Alterações Realizadas

- **Mantém permissões existentes**: `contents: write`, `pages: write`, `id-token: write`
- **Adiciona novas permissões**: 
  - `actions: read` - Para ler informações das actions
  - `deployments: write` - Para escrever deployments
- **Adiciona comentário explicativo** sobre o fix para erro 403

## Justificativa

Essas permissões são necessárias para que o workflow do GitHub Actions tenha acesso adequado ao GitHub Pages e possa realizar o deployment sem retornar erro 403 (Forbidden).

## Testes

Após o merge, o workflow poderá ser executado com as novas permissões para verificar se o erro 403 foi resolvido.…x: Add enhanced GITHUB_TOKEN permissions for GitHub Actions PagesUpdate GITHUB_TOKEN permissions for Actions Pages

Corrige erro 403 no GitHub Actions Pages adicionando permissões adicionais ao GITHUB_TOKEN:

- Mantém permissões existentes: contents: write, pages: write, id-token: write
- Adiciona: actions: read, deployments: write
- Adiciona comentário explicativo sobre o fix para erro 403

Corrige erro 403 no GitHub Actions Pages adicionando permissões adicionais ao GITHUB_TOKEN:

- Mantém permissões existentes: contents: write, pages: write, id-token: write
- Adiciona: actions: read, deployments: write
- Adiciona comentário explicativo sobre o fix para erro 403

Essas permissões são necessárias para o deployment correto no GitHub Pages via Actions.Essas permissões são necessárias para o deployment correto no GitHub Pages via Actions.Fixes 403 error in GitHub Actions Pages by updating permissions for GITHUB_TOKEN.